### PR TITLE
Fixes for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The library does not requires any libraries, but demo scripts require:
 - PIL (Python imaging library)
 - Matplotlib
 
+The library works under both Python 2 and 3.
+
 ### Modules provided:
 - **tsp_solver.greedy** : Basic greedy TSP solver in Python
 - **tsp_solver.greedy_numpy** : Version that uses Numpy matrices, which reduces memory use, but performance is several percents lower

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 
 setup(name='tsp_solver2',
       version='0.3',

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,16 @@ try:
 except ImportError:
     from distutils.core import setup
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
 
 setup(name='tsp_solver2',
       version='0.3',
       description='Greedy, suboptimal solver for the Travelling Salesman Problem',
       author='Dmitry Shintyakov',
       author_email='shintyakov@gmail.com',
+      long_description=long_description,
+      long_description_content_type="text/markdown",
       url='https://github.com/dmishin/tsp-solver',
       packages=['tsp_solver', 'tsp_solver.demo'],
       keywords=['travelling salesman problem', 'optimization'],

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,14 @@ setup(name='tsp_solver2',
       packages=['tsp_solver', 'tsp_solver.demo'],
       keywords=['travelling salesman problem', 'optimization'],
       scripts=['bin/tsp_demo', 'bin/tsp_numpy2svg'],
-      license="free domain"
+      license="free domain",
+      classifiers=[
+          'License :: Public Domain',
+          'Operating System :: OS Independent',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+      ],
       )


### PR DESCRIPTION
This pull request does three things:

* Use `setuptools` before `distutils` if it's available. `setuptools` is newer and is [recommended by the Python Packaging Authority](https://packaging.python.org/guides/tool-recommendations/#packaging-tool-recommendations).
* Add the `long_description` option to `setup()` with the content from the README. The long description is shown on the project's PyPI page (e.g. compare [tsp_solver2's page](https://pypi.org/project/tsp_solver2/) with [requests'](https://pypi.org/project/requests/)). Note that in order to make this work with a Markdown README (as opposed to one in ReStructuredText which was the only supported format in the past), [`setuptools>=38.6.0`](https://stackoverflow.com/questions/26737222/pypi-description-markdown-doesnt-work/26737258#26737258) is required when building the source distribution (and possibly `twine>=1.11.0` if you use that to upload new versions).
* Add classifiers that PyPI automatically can parse to determine license, OS support and Python version support. Specifically the Python version classifiers makes it possible for tools such as [caniusepython3.com](https://caniusepython3.com/) to automatically determine if Python 3 is supported by a project.

Please let me know if you'd like me to change anything in the PR or if you have any comments.