### PR TITLE
Export modules in __init__.py.

### DIFF
--- a/tsp_solver/__init__.py
+++ b/tsp_solver/__init__.py
@@ -1,0 +1,1 @@
+from . import greedy, greedy_numpy, util


### PR DESCRIPTION
This allows users to do
```python3
import tsp_solver

tsp_solver.greedy
tsp_solver.greedy_numpy
tsp_solver.util
```
instead of the less convenient
```python3
import tsp_solver.greedy
import tsp_solver.greedy_numpy
import tsp_solver.util

tsp_solver.greedy
tsp_solver.greedy_numpy
tsp_solver.util
```
or
```python3
from tsp_solver import greedy, greedy_numpy, util

greedy
greedy_numpy
util
```